### PR TITLE
Added group related condition and use a separated variable for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Elasticsearch master node with optional ec2 discovery.  Elasticsearch indices ar
 
 The following environment variables can be used to configure the container:
 
-    ES_CLUSTER_NAME     The name of the elasticsearch cluster, default is "elasticsearch".  This is also
-                        the ec2 group name that is used for discovery.
+    ES_CLUSTER_NAME     The name of the elasticsearch cluster, default is "elasticsearch".
     ES_DISCOVERY        The type of discovery to use with elasticsearch, if not set will use multicast. Setting to "ec2"
     					will enable ec2 discovery using ES_CLUSTER_NAME in ES_AWS_REGION.
     ES_AWS_REGION       The aws region to be used for discovery, default is "us-east-1".
+    ES_AWS_GROUP        The name or the id of the security group that is used for discovery. Optional.
     ES_AWS_ACCESS_KEY   The aws access key to be used for discovery.  Not required if
                         the instance profile has ec2 DescribeInstance permissions.
     ES_AWS_SECRET_KEY   The aws secret key to be used for discovery.  Not required if

--- a/run
+++ b/run
@@ -26,8 +26,14 @@ fi
 	cat >> /opt/elasticsearch/config/elasticsearch.yml << EOF
 discovery:
   type: ec2
-  ec2:
-    groups: $ES_CLUSTER_NAME
 EOF
+
+if [ "$ES_AWS_GROUP" != "" ] ; then
+cat >> /opt/elasticsearch/config/elasticsearch.yml << EOF
+  ec2:
+    groups: $ES_AWS_GROUP
+EOF
+fi
+
 fi
 /usr/bin/supervisord -c /etc/supervisor/conf.d/elasticsearch.conf


### PR DESCRIPTION
I would like to create an Elastic search cluster from Cloud formation template. The only problem is that i have to use the same name for the cluster and the security group to make sure that all of the instances will be discovered. I cannot set the name of a cluster or the name of a security group in a Cloud formation template, these are generated automatically and never be the same. I introduced a new environment variable for the groups and made it optional to solve this problem.